### PR TITLE
Create PRESIDENCY - REPORT TO THE IMC - RFI-Breakdown PPEs Expenditur…

### DIFF
--- a/PRESIDENCY - REPORT TO THE IMC - RFI-Breakdown PPEs Expenditure 12 AUG 2020 - Petty Cash Table.csv
+++ b/PRESIDENCY - REPORT TO THE IMC - RFI-Breakdown PPEs Expenditure 12 AUG 2020 - Petty Cash Table.csv
@@ -1,0 +1,46 @@
+Details of Goods or Services,Method of Procurement,Procurement process followed,Companies Appointed,Date of purchase,Purchase Amount
+Masks,Off-shelf -procurement,Petty Cash,Biologica,4/7/2020,"R              1,332.50"
+Sanitizer,Off-shelf -procurement,Petty Cash,Blueblack,3/26/2020,"R              1,345.50"
+Masks,Off-shelf -procurement,Petty Cash,Swaamstraat Pharmacy,3/29/2020,"R              1,488.00"
+Thermometer,Off-shelf -procurement,Petty Cash,Bernina Gezina,5/15/2020,"R              1,195.00"
+Funnel for Sanitizer,Off-shelf -procurement,Petty Cash,Westpak Lifestyle,5/5/2020,R103.20
+Stick-on note,Off-shelf -procurement,Petty Cash,PNA Loftus,5/5/2020,R99.00
+Stick-on note & Floor decals for social dis,Oanffc-isnhgelf -procurement,Petty Cash,Minuteman Press,5/13/2020,"R              1,499.23"
+Masks,Off-shelf -procurement,Petty Cash,Msibi Hotel services,3/26/2020,"R              1,470.00"
+Sanitizer,Off-shelf -procurement,Petty Cash,Dischem,5/15/2020,R134.85
+Masks,Off-shelf -procurement,Petty Cash,Dischem,5/15/2020,R997.95
+Gloves,Off-shelf -procurement,Petty Cash,Dischem,4/8/2020,R299.90
+Masks,Off-shelf -procurement,Petty Cash,Dischem,4/8/2020,R155.70
+Masks,Off-shelf -procurement,Petty Cash,Dischem,4/8/2020,R279.30
+Masks,Off-shelf -procurement,Petty Cash,Dischem,4/8/2020,R698.20
+Masks,Off-shelf -procurement,Petty Cash,Dischem,5/14/2020,R997.90
+Thermometer,Off-shelf -procurement,Petty Cash,Bernina Gezina,5/15/2020,"R              1,195.00"
+Thermometer,Off-shelf -procurement,Petty Cash,S.Salie,5/8/2020,"R              2,000.00"
+Masks,Off-shelf -procurement,Petty Cash,KIS Clothing,5/6/2020,R810.00
+Sanitizer,Off-shelf -procurement,Petty Cash,Builders warehouse,5/6/2020,R90.00
+Gloves,Off-shelf -procurement,Petty Cash,Dischem,4/29/2020,R299.90
+Face Masks,Off-shelf -procurement,Petty Cash,Yinginaka creative Home,5/10/2020,"R              1,760.00"
+Thermometer,Off-shelf -procurement,Petty Cash,Bio Boy,5/8/2020,"R              2,000.00"
+faceshield,Off-shelf -procurement,Petty Cash,Signarama,5/13/2020,R286.93
+faceshield,Off-shelf -procurement,Petty Cash,M-kem medicin city,5/7/2020,R134.97
+hand sanitizer,Off-shelf -procurement,Petty Cash,Dis Chem,5/7/2020,R519.97
+Thermometer,Off-shelf -procurement,Petty Cash,Big Boy Crockery,5/9/2020,"R              1,750.00"
+Mask,Off-shelf -procurement,Petty Cash,Kis Clothing,5/11/2020,"R              1,350.00"
+Spray bottles,Off-shelf -procurement,Petty Cash,Bio Boy,5/12/2020,R780.00
+hand sanitizer,Off-shelf -procurement,Petty Cash,Dis Chem,6/18/2020,R840.90
+Spray bottles,Off-shelf -procurement,Petty Cash,Homewear lifestyle,7/9/2020,R750.00
+Mask,Off-shelf -procurement,Petty Cash,Rashiedas Mask,5/18/2020,"R              1,460.00"
+Spray bottles,Off-shelf -procurement,Petty Cash,lifestyle Fabrics,6/23/2020,R617.00
+Spray bottles,Off-shelf -procurement,Petty Cash,Kenilworth,6/25/2020,R801.80
+Gloves,Off-shelf -procurement,Petty Cash,Dis Chem,6/24/2020,"R              1,310.50"
+Spray bottles,Off-shelf -procurement,Petty Cash,lifestyle Fabrics,6/17/2020,"R              1,157.30"
+Spray bottles,Off-shelf -procurement,Petty Cash,Crazy Plastics,6/11/2020,R279.93
+Spray bottles,Off-shelf -procurement,Petty Cash,Linas Toys & Jewelry,6/8/2020,R105.00
+Stickers,Off-shelf -procurement,Petty Cash,Minuteman Press,6/9/2020,"R              1,499.23"
+Spray bottles,Off-shelf -procurement,Petty Cash,West Pack Lifestyle,5/29/2020,R159.20
+Spray bottles,Off-shelf -procurement,Petty Cash,Plastic R US,6/2/2020,"R              1,000.00"
+Spray bottles,Off-shelf -procurement,Petty Cash,Makro,6/5/2020,R351.00
+hand sanitizer,Off-shelf -procurement,Petty Cash,G-FOX PTY LTD,6/3/2020,R756.70
+hand sanitizer,Off-shelf -procurement,Petty Cash,Health Services pty ltd,6/3/2020,"R              1,380.00"
+Spray bottles,Off-shelf -procurement,Petty Cash,Health Services pty ltd,6/3/2020,R322.00
+Funnel,Off-shelf -procurement,Petty Cash,Osbro Cash & Carry,6/3/2020,R14.00


### PR DESCRIPTION
…e 12 AUG 2020 - Petty Cash Table.csv

This is file 1/2 of the PDF report PRESIDENCY - REPORT TO THE IMC - RFI-Breakdown PPEs Expenditure 12 AUG 2020 the reason being there are two different tables in the PDF. #41